### PR TITLE
Add support for H5108 WiFi Refrigerator Thermometer and alarm event h…

### DIFF
--- a/docs/SKUS.md
+++ b/docs/SKUS.md
@@ -19,5 +19,6 @@ limitation of Govee2MQTT, but a limitation of the hardware itself.
 |Humidifiers|Not supported by these devices|Most humidifiers are controllable via the Platform API, but the level of control can be patchy; some models cannot have their night lights controlled fully at this time due to bugs on Govee's side.|Only the H7160 at this time. It allows control over the night light|
 |Kettles|Not supported by these devices|Tested with H7171 and H7173|No|
 |Heaters, Fans, Purifiers|Not supported by these devices|Tested with H7101, H7102, H7111, H7121, H7130, H7131, H713A, H7135|No|
+|Thermometers|Not supported by these devices|Tested with H5051, H5100, H5103, H5108, H5179. These devices provide temperature and humidity readings, and may include alarm notifications for threshold alerts.|No|
 |Plugs|Not supported by these devices|Yes, but the API is buggy and support may be limited. ([H5082](https://github.com/wez/govee2mqtt/issues/65))|No|
 

--- a/src/hass_mqtt/binary_sensor.rs
+++ b/src/hass_mqtt/binary_sensor.rs
@@ -1,0 +1,125 @@
+use crate::hass_mqtt::base::{Device, EntityConfig, Origin};
+use crate::hass_mqtt::instance::{publish_entity_config, EntityInstance};
+use crate::platform_api::DeviceCapability;
+use crate::service::device::Device as ServiceDevice;
+use crate::service::hass::{availability_topic, topic_safe_id, topic_safe_string, HassClient};
+use crate::service::state::StateHandle;
+use async_trait::async_trait;
+use serde::Serialize;
+
+#[derive(Serialize, Clone, Debug)]
+pub struct BinarySensorConfig {
+    #[serde(flatten)]
+    pub base: EntityConfig,
+
+    pub state_topic: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_class: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload_on: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload_off: Option<String>,
+}
+
+impl BinarySensorConfig {
+    pub async fn publish(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
+        publish_entity_config("binary_sensor", state, client, &self.base, self).await
+    }
+
+    pub async fn notify_state(&self, client: &HassClient, value: &str) -> anyhow::Result<()> {
+        client.publish(&self.state_topic, value).await
+    }
+}
+
+#[derive(Clone)]
+pub struct AlarmEventSensor {
+    sensor: BinarySensorConfig,
+    device_id: String,
+    state: StateHandle,
+    instance_name: String,
+}
+
+impl AlarmEventSensor {
+    pub async fn new(
+        device: &ServiceDevice,
+        state: &StateHandle,
+        instance: &DeviceCapability,
+    ) -> anyhow::Result<Self> {
+        let unique_id = format!(
+            "binary-sensor-{id}-{inst}",
+            id = topic_safe_id(device),
+            inst = topic_safe_string(&instance.instance)
+        );
+
+        // Determine device class and name based on event type
+        let (device_class, name) = match instance.instance.as_str() {
+            "lowBatteryEvent" => (Some("battery"), "Low Battery"),
+            "lackWaterEvent" => (Some("problem"), "Water Level Alert"),
+            "temperatureAlarmEvent" | "tempAlarmEvent" => (Some("problem"), "Temperature Alarm"),
+            "humidityAlarmEvent" | "humAlarmEvent" => (Some("problem"), "Humidity Alarm"),
+            s if s.ends_with("AlarmEvent") => (Some("problem"), "Alarm"),
+            s if s.ends_with("Event") => (Some("problem"), "Alert"),
+            _ => (None, "Event"),
+        };
+
+        let name = name.to_string();
+
+        Ok(Self {
+            sensor: BinarySensorConfig {
+                base: EntityConfig {
+                    availability_topic: availability_topic(),
+                    name: Some(name),
+                    entity_category: Some("diagnostic".to_string()),
+                    origin: Origin::default(),
+                    device: Device::for_device(device),
+                    unique_id: unique_id.clone(),
+                    device_class: device_class.map(|s| s.to_string()),
+                    icon: None,
+                },
+                state_topic: format!("gv2mqtt/binary_sensor/{unique_id}/state"),
+                device_class,
+                payload_on: Some("ON".to_string()),
+                payload_off: Some("OFF".to_string()),
+            },
+            device_id: device.id.to_string(),
+            state: state.clone(),
+            instance_name: instance.instance.to_string(),
+        })
+    }
+}
+
+#[async_trait]
+impl EntityInstance for AlarmEventSensor {
+    async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
+        self.sensor.publish(&state, &client).await
+    }
+
+    async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
+        let device = self
+            .state
+            .device_by_id(&self.device_id)
+            .await
+            .expect("device to exist");
+
+        if let Some(cap) = device.get_state_capability_by_instance(&self.instance_name) {
+            // Try to extract alarm state from the capability state
+            // Events typically have a value field indicating if the alarm is active
+            let is_active = cap
+                .state
+                .pointer("/value")
+                .and_then(|v| v.as_i64())
+                .map(|v| v != 0)
+                .unwrap_or(false);
+
+            let state_value = if is_active { "ON" } else { "OFF" };
+            return self.sensor.notify_state(&client, state_value).await;
+        }
+
+        log::trace!(
+            "AlarmEventSensor::notify_state: didn't find state for {device} {instance}",
+            instance = self.instance_name
+        );
+        Ok(())
+    }
+}
+

--- a/src/hass_mqtt/enumerator.rs
+++ b/src/hass_mqtt/enumerator.rs
@@ -1,4 +1,5 @@
 use crate::hass_mqtt::base::{Device, EntityConfig, Origin};
+use crate::hass_mqtt::binary_sensor::AlarmEventSensor;
 use crate::hass_mqtt::button::ButtonConfig;
 use crate::hass_mqtt::climate::TargetTemperatureEntity;
 use crate::hass_mqtt::humidifier::Humidifier;
@@ -182,9 +183,15 @@ pub async fn enumerate_entities_for_device<'a>(
                 DeviceCapabilityKind::ColorSetting
                 | DeviceCapabilityKind::SegmentColorSetting
                 | DeviceCapabilityKind::MusicSetting
-                | DeviceCapabilityKind::Event
                 | DeviceCapabilityKind::Mode
                 | DeviceCapabilityKind::DynamicScene => {}
+
+                DeviceCapabilityKind::Event => {
+                    // Handle alarm/event capabilities as binary sensors
+                    if cap.alarm_type.is_some() || cap.event_state.is_some() {
+                        entities.add(AlarmEventSensor::new(&d, state, cap).await?);
+                    }
+                }
 
                 DeviceCapabilityKind::Range if cap.instance == "brightness" => {}
                 DeviceCapabilityKind::Range if cap.instance == "humidity" => {}

--- a/src/hass_mqtt/mod.rs
+++ b/src/hass_mqtt/mod.rs
@@ -1,4 +1,5 @@
 pub mod base;
+pub mod binary_sensor;
 pub mod button;
 pub mod climate;
 pub mod cover;

--- a/src/hass_mqtt/sensor.rs
+++ b/src/hass_mqtt/sensor.rs
@@ -134,6 +134,24 @@ impl CapabilitySensor {
             "sensorTemperature" => "Temperature".to_string(),
             "sensorHumidity" => "Humidity".to_string(),
             "online" => "Connected to Govee Cloud".to_string(),
+            "lowBatteryEvent" => "Low Battery".to_string(),
+            "lackWaterEvent" => "Water Level".to_string(),
+            s if s.ends_with("Event") => {
+                // Convert camelCase Event names to readable format
+                s.trim_end_matches("Event")
+                    .chars()
+                    .enumerate()
+                    .flat_map(|(i, c)| {
+                        if i > 0 && c.is_uppercase() {
+                            vec![' ', c]
+                        } else if i == 0 {
+                            vec![c.to_ascii_uppercase()]
+                        } else {
+                            vec![c]
+                        }
+                    })
+                    .collect::<String>()
+            }
             _ => instance.instance.to_string(),
         };
 

--- a/src/service/quirks.rs
+++ b/src/service/quirks.rs
@@ -257,6 +257,9 @@ fn load_quirks() -> HashMap<String, Quirk> {
         Quirk::thermometer("H5179")
             .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit)
             .with_platform_humidity_sensor_units(HumidityUnits::RelativePercent),
+        Quirk::thermometer("H5108")
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit)
+            .with_platform_humidity_sensor_units(HumidityUnits::RelativePercent),
         Quirk::device("H7170", DeviceType::Kettle, "mdi:kettle")
             .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit),
         Quirk::device("H7171", DeviceType::Kettle, "mdi:kettle")


### PR DESCRIPTION
…andling

This commit adds comprehensive support for the GoveeLife WiFi Refrigerator Thermometer with Alarm (H5108) and introduces a general-purpose binary sensor system for handling alarm/event capabilities from any Govee device.

Changes:

- Added H5108 thermometer quirk with proper sensor unit configurations

- Created binary_sensor module to handle alarm/event capabilities

- Automatically maps event types to appropriate HA device classes

- Enhanced event name formatting for better user experience

- Updated entity enumeration to process Event capabilities

- Updated documentation with thermometer device support

This enhancement benefits H5108 users and any device that exposes alarm/event capabilities (humidifiers, heaters, etc.).

No breaking changes. Existing devices continue to work unchanged.